### PR TITLE
Replace absolute imports by relative imports.

### DIFF
--- a/clang/cindex.py
+++ b/clang/cindex.py
@@ -65,7 +65,7 @@ call is efficient.
 from ctypes import *
 import collections
 
-import clang.enumerations
+from . import enumerations
 
 # ctypes doesn't implicitly convert c_void_p to the appropriate wrapper
 # object. This is a problem, because it means that from_parameter will see an
@@ -3880,7 +3880,7 @@ class Config:
         return True
 
 def register_enumerations():
-    for name, value in clang.enumerations.TokenKinds:
+    for name, value in enumerations.TokenKinds:
         TokenKind.register(value, name)
 
 conf = Config()


### PR DESCRIPTION
This allows reuse the code within projects,
even if their path witin the project differs from 'clang.cindex'.